### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
     "graphql": "^0.7.0",
     "graphql-date": "^1.0.2",
     "humanize-duration": "^3.9.1",
-    "node-uuid": "^1.4.7",
     "read": "^1.0.7",
     "request": "^2.75.0",
-    "supports-color": "^3.1.2"
+    "supports-color": "^3.1.2",
+    "uuid": "^3.0.0"
   },
   "config": {
     "port": 3000

--- a/src/expiring-map.js
+++ b/src/expiring-map.js
@@ -8,7 +8,7 @@
 import util from 'util'
 import formatDuration from 'humanize-duration'
 import { EventEmitter } from 'events'
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 
 const debug = require('debug')('foobot-graphql:expiring-map')
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.